### PR TITLE
handling encoder values of wheels

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ find_package(catkin REQUIRED COMPONENTS
   smart_battery_msgs
   roscpp
   gopigo
+  message_generation
 )
 
 #find_package(gopigo REQUIRED)
@@ -54,11 +55,10 @@ find_package(catkin REQUIRED COMPONENTS
 # )
 
 ## Generate services in the 'srv' folder
-# add_service_files(
-#   FILES
-#   Service1.srv
-#   Service2.srv
-# )
+add_service_files(
+  FILES
+  SimpleWrite.srv
+)
 
 ## Generate actions in the 'action' folder
 # add_action_files(
@@ -68,10 +68,10 @@ find_package(catkin REQUIRED COMPONENTS
 # )
 
 ## Generate added messages and services with any dependencies listed here
-# generate_messages(
-#   DEPENDENCIES
-#   geometry_msgs
-# )
+generate_messages(
+  DEPENDENCIES
+#  geometry_msgs
+)
 
 ################################################
 ## Declare ROS dynamic reconfigure parameters ##

--- a/launch/ropigo.launch
+++ b/launch/ropigo.launch
@@ -1,0 +1,4 @@
+<launch>
+  <env name="ROSCONSOLE_CONFIG_FILE" value="$(find ropigo)/launch/rosconsole_dbg.conf"/>
+  <node pkg="ropigo" type="ropigo_node" name="ropigo_node" output="screen"/>
+</launch>

--- a/launch/rosconsole_dbg.conf
+++ b/launch/rosconsole_dbg.conf
@@ -1,0 +1,8 @@
+#
+#   rosconsole will find this file by default at $ROS_ROOT/config/rosconsole.config
+#
+#   You can define your own by e.g. copying this file and setting
+#   ROSCONSOLE_CONFIG_FILE (in your environment) to point to the new file
+#
+log4j.logger.ros=DEBUG
+log4j.logger.ros.roscpp.superdebug=WARN

--- a/src/ropigo.cpp
+++ b/src/ropigo.cpp
@@ -2,6 +2,7 @@
 #include <std_msgs/Int16.h>
 #include <geometry_msgs/Twist.h>
 #include <smart_battery_msgs/SmartBatteryStatus.h>
+#include <ropigo/SimpleWrite.h>
 
 extern "C" {
 #include <gopigo.h>
@@ -57,6 +58,20 @@ void cmdCallback(const geometry_msgs::Twist::ConstPtr& msg) {
     }
 }
 
+bool enc_enable(ropigo::SimpleWrite::Request &req, ropigo::SimpleWrite::Response &res) {
+    int ret = enable_encoders();
+    if(ret!=1)
+        ROS_WARN("Error enabling encoders!");
+    return ret;
+}
+
+bool enc_disable(ropigo::SimpleWrite::Request &req, ropigo::SimpleWrite::Response &res) {
+    int ret = disable_encoders();
+    if(ret!=1)
+        ROS_WARN("Error disabling encoders!");
+    return ret;
+}
+
 int main(int argc, char **argv) {
 
     init();
@@ -74,6 +89,11 @@ int main(int argc, char **argv) {
     // odometry
     ros::Publisher lwheel_pub = n.advertise<std_msgs::Int16>("lwheel",1);
     ros::Publisher rwheel_pub = n.advertise<std_msgs::Int16>("rwheel",1);
+
+    /// Services
+    // Encoder
+    ros::ServiceServer enc_enable_srv = n.advertiseService("encoder_enable", enc_enable);
+    ros::ServiceServer enc_disable_srv = n.advertiseService("encoder_disable", enc_disable);
 
     ros::Rate loop(10);
 

--- a/src/ropigo.cpp
+++ b/src/ropigo.cpp
@@ -21,7 +21,10 @@ void cmdCallback(const geometry_msgs::Twist::ConstPtr& msg) {
 
     // ignore small values
     if(mag <= 0.1) {
-        stop();
+        ROS_DEBUG("Not moving");
+        if( stop() != 1) {
+            ROS_WARN("Could not stop!");
+        }
         return;
     }
 
@@ -45,8 +48,13 @@ void cmdCallback(const geometry_msgs::Twist::ConstPtr& msg) {
 
     ROS_DEBUG("writing values (motor1, motor2): (%i)%i, (%i)%i", std::max(0, int(m1/std::abs(m1))), int(m1*255), std::max(0, int(m2/std::abs(m2))), int(m2*255));
 
-    motor1(m1>=0, std::abs(int(m1*255)));
-    motor2(m2>=0, std::abs(int(m2*255)));
+    if( motor1(m1>=0, std::abs(int(m1*255))) != 1 ) {
+        ROS_WARN("Error when writing to motor 1");
+    }
+
+    if( motor2(m2>=0, std::abs(int(m2*255))) != 1) {
+        ROS_WARN("Error when writing to motor 2");
+    }
 }
 
 int main(int argc, char **argv) {

--- a/src/ropigo.cpp
+++ b/src/ropigo.cpp
@@ -67,7 +67,7 @@ int main(int argc, char **argv) {
     ros::Publisher lwheel_pub = n.advertise<std_msgs::Int16>("lwheel",1);
     ros::Publisher rwheel_pub = n.advertise<std_msgs::Int16>("rwheel",1);
 
-    ros::Rate loop(1);
+    ros::Rate loop(10);
 
     while(ros::ok()) {
         smart_battery_msgs::SmartBatteryStatus battery;

--- a/src/ropigo.cpp
+++ b/src/ropigo.cpp
@@ -1,4 +1,5 @@
 #include <ros/ros.h>
+#include <std_msgs/Int16.h>
 #include <geometry_msgs/Twist.h>
 #include <smart_battery_msgs/SmartBatteryStatus.h>
 
@@ -57,16 +58,30 @@ int main(int argc, char **argv) {
 
     ros::init(argc, argv, "ropigo");
     ros::NodeHandle n;
+
     ros::Subscriber cmd = n.subscribe("cmd_vel", 1000, cmdCallback);
+
     ros::Publisher battery_pub = n.advertise<smart_battery_msgs::SmartBatteryStatus>("battery",1);
+
+    // odometry
+    ros::Publisher lwheel_pub = n.advertise<std_msgs::Int16>("lwheel",1);
+    ros::Publisher rwheel_pub = n.advertise<std_msgs::Int16>("rwheel",1);
 
     ros::Rate loop(1);
 
     while(ros::ok()) {
         smart_battery_msgs::SmartBatteryStatus battery;
+        std_msgs::Int16 lwheel, rwheel;
+
         battery.voltage = volt();
 
+        lwheel.data = (int16_t)enc_read(0);
+        rwheel.data = (int16_t)enc_read(1);
+
+        // publish topics
         battery_pub.publish(battery);
+        lwheel_pub.publish(lwheel);
+        rwheel_pub.publish(rwheel);
 
         ros::spinOnce();
         loop.sleep();

--- a/srv/SimpleWrite.srv
+++ b/srv/SimpleWrite.srv
@@ -1,0 +1,2 @@
+---
+int8 status


### PR DESCRIPTION
These commits implement the access to the GoPiGo encoder. The topics _lwheel_ and _rwheel_ publish the encoder values of the left and right wheel in centimetres. The service _encoder_disable_ stops counting encoder values and _encoder_enable_ continues to count from the last value.
